### PR TITLE
Set HTTP::Response base if not already in headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .build/
 WWW-Curl-UserAgent-*
+**~

--- a/lib/WWW/Curl/UserAgent.pm
+++ b/lib/WWW/Curl/UserAgent.pm
@@ -7,6 +7,7 @@ use v5.10;
 
 use WWW::Curl::Easy;
 use WWW::Curl::Multi;
+use HTTP::Request;
 use HTTP::Response;
 use Time::HiRes;
 use IO::Select;
@@ -214,7 +215,22 @@ sub _perform_callbacks {
         my $curl_easy = $request->curl_easy;
 
         if ( $return_code == 0 ) {
-            my $response = $self->_build_http_response( ${ $request->header_ref }, ${ $request->content_ref }, $curl_easy );
+
+            # Assume the final http request is the original one
+            my $final_http_request = $request->http_request();
+            my $effective_url = $curl_easy->getinfo( CURLINFO_EFFECTIVE_URL );
+            
+            # Handle redirection last effective Request so
+            # the response is always link to the last request in effect.
+            if( $effective_url && (  $final_http_request->uri().'' ne $effective_url ) ){
+                $final_http_request = HTTP::Request
+                    ->new($final_http_request->method,
+                          $effective_url,
+                          $final_http_request->headers(),
+                          $final_http_request->content());
+            }
+            
+            my $response = $self->_build_http_response( ${ $request->header_ref }, ${ $request->content_ref }, $final_http_request );
             $handler->on_success->( $request->http_request, $response, $curl_easy );
         }
         else {
@@ -258,19 +274,16 @@ sub _build_http_response {
     my $self    = shift;
     my $header  = shift;
     my $content = shift;
-    my $curl_easy = shift;
+    my $final_http_request = shift;
 
     # PUT requests may contain continue header
     my @header = split "\r\n\r\n", $header;
 
     my $response = HTTP::Response->parse($header[-1]);
 
-    if( $curl_easy &&
-        ( my $effective_url = $curl_easy->getinfo( CURLINFO_EFFECTIVE_URL ))){
-        unless( $response->base() ){
-            # This will cause base to be set.
-            $response->header('Base' => $effective_url);
-        }
+    if( $final_http_request ){
+        # Inject this in the response to behave more like LWP::UserAgent
+        $response->request($final_http_request);
     }
 
     $response->content($content) if defined $content;

--- a/t/03_perform.t
+++ b/t/03_perform.t
@@ -4,7 +4,7 @@ use warnings;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 
-use Test::More tests => 30;
+use Test::More tests => 29;
 
 use HTTP::Request;
 use Sub::Override;
@@ -112,16 +112,6 @@ EOF
 {
     note 'build default http response';
 
-    my $curl_easy = Test::MockObject->new();
-    # Mock getinfo so it returns http://www.example.
-    $curl_easy->mock('getinfo', sub{
-                       my ($self, $info_key) = @_;
-                       if( $info_key == CURLINFO_EFFECTIVE_URL ){
-                         return 'http://www.example.com';
-                       }
-                       die "Un-mocked info key ".$info_key;
-                     });
-    
     my $http_response_header = <<EOF;
 HTTP/1.1 200 OK\r
 Content-Length: 12\r
@@ -130,11 +120,10 @@ Content-Type: text/plain\r
 EOF
     my $http_response_body = 'some content';
     
-    my $response = WWW::Curl::UserAgent->_build_http_response($http_response_header, $http_response_body, $curl_easy);
+    my $response = WWW::Curl::UserAgent->_build_http_response($http_response_header, $http_response_body);
     is $response->code, 200;
     is $response->message, 'OK';
     is $response->content, $http_response_body;
-    is $response->base, 'http://www.example.com';
 }
 
 {

--- a/xt/release/response_base.t
+++ b/xt/release/response_base.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use Test::More;
+
+use HTTP::Request;
+use Sub::Override;
+## use Test::MockObject;
+
+use WWW::Curl::Easy;
+
+BEGIN {
+    use_ok('WWW::Curl::UserAgent');
+}
+
+my $ua = WWW::Curl::UserAgent->new(
+                                   timeout => 10000,
+                                   connect_timeout => 5000,
+                                   followlocation => 1,
+                                  );
+
+
+{
+  # Test a standard non redirecting request.
+  my $req = HTTP::Request->new( 'GET' => 'http://www.example.com' );
+  my $resp = $ua->request($req);
+  ok( $resp->is_success() , "Response is a success");
+  ok( $resp->request() , "Got request from response");
+  is( $resp->base()  , 'http://www.example.com' );
+}
+
+{
+  # Test a redirecting one (will get to www.example.com)
+  my $req = HTTP::Request->new( 'GET' => 'http://bit.ly/1h0ceQI' );
+  my $resp = $ua->request($req);
+  ok( $resp->is_success() , "Response is a success");
+  ok( $resp->request() , "Got request from response");
+  is( $resp->base()  , 'http://www.example.com/' );
+}
+
+done_testing();


### PR DESCRIPTION
Hi, I love WWW::Curl::UserAgent, but something that annoys me is the lack of 'base' in the HTTP::Responses it generates. Hopefully this is a cure that will also work accross redirections.

Cheers.
