### PR TITLE
fixed mojo benchmark test

### DIFF
--- a/tools/benchmark.pl
+++ b/tools/benchmark.pl
@@ -53,7 +53,10 @@ sub lwp_parallel_useragent_multi {
 
 sub mojo_useragent_multi {
     my $delay = Mojo::IOLoop->delay;
-    $mojo_useragent->get($url => sub {}) for ( 1.. 5 );
+    for (1 .. 5) {
+        my $end = $delay->begin;
+        $mojo_useragent->get($url => sub { $end->() });
+    }
     $delay->wait;
 }
 


### PR DESCRIPTION
I think the benchmark test for Mojo::UserAgent's parallel request should look like this.
It scores higher than LWP::Parallel::UserAgent on my environment.
